### PR TITLE
Mobile sidebar fixes

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,15 +1,24 @@
 import React from "react";
 import * as styles from "../styled-components/HeaderStyles.js";
+import { useLayoutContext } from './PageLayout.jsx';
 import AppBar  from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import Button from "@mui/material/Button";
 
-export default function Header({ title }){
+export default function Header(){
+    const Context = useLayoutContext();
+
     return(
         <AppBar position='sticky'>
             <Toolbar disableGutters>
                 <styles.HeaderLeftBox>
-                    {title}
+                    <styles.SidebarButton
+                        onClick={() => Context.setSidebarOpen(!Context.sidebarOpen)}
+                        disableTouchRipple
+                    >
+                        ☰
+                    </styles.SidebarButton>
+                    {Context.selectedTabName}
                 </styles.HeaderLeftBox>
                 <styles.HeaderRightBox>
                     <Button

--- a/client/src/components/PageLayout.jsx
+++ b/client/src/components/PageLayout.jsx
@@ -15,7 +15,7 @@ import TabList from './TabList.jsx';
 import bannerImage from '../assets/jarvis_banner.png';
 import Header from './Header.jsx';
 
-export const LayoutContext = React.createContext(undefined);
+const LayoutContext = React.createContext(undefined);
 export function useLayoutContext() {
     const context = useContext(LayoutContext);
     if (context === undefined) {
@@ -29,19 +29,15 @@ export default function PageLayout() {
     const [sidebarOpen, setSidebarOpen] = React.useState(!mobile);
     const [selectedTabName, setSelectedTabName] = useState('UMSATS');
 
-    const toggleSidebar = (newOpen) => () => {
-        setSidebarOpen(newOpen);
-    }
-
     return (
         <ThemeProvider theme={theme}>
         <CssBaseline />
-        <Box display='inline'>
+        <Box>
             <styles.Sidebar
                 open={sidebarOpen}
                 mobile={mobile}
                 variant={mobile ? 'temporary' : 'persistent'}
-                onClose={toggleSidebar(false)}
+                onClose={() => {setSidebarOpen(false)}}
             >
                 <Box display='flex' flexDirection='column'>
                     <img src={bannerImage} alt='banner'

--- a/client/src/components/PageLayout.jsx
+++ b/client/src/components/PageLayout.jsx
@@ -3,7 +3,7 @@ Implements a sidebar and its toggle button into the flow of the website.
 Wraps the routes in index.js directly, making each page simpler to implement.
 */
 
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Outlet  } from "react-router-dom";
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from './theme.jsx';
@@ -14,6 +14,15 @@ import Box from '@mui/material/Box';
 import TabList from './TabList.jsx';
 import bannerImage from '../assets/jarvis_banner.png';
 import Header from './Header.jsx';
+
+export const LayoutContext = React.createContext(undefined);
+export function useLayoutContext() {
+    const context = useContext(LayoutContext);
+    if (context === undefined) {
+        throw new Error("useLayoutContext is missing a provider or values");
+    }
+    return context;
+}
 
 export default function PageLayout() {
     const mobile = useMediaQuery(theme.breakpoints.down('mobile'));
@@ -37,7 +46,9 @@ export default function PageLayout() {
                 <Box display='flex' flexDirection='column'>
                     <img src={bannerImage} alt='banner'
                          style={{margin: '12px', borderRadius: '8px'}}/>
-                    <TabList setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
+                    <LayoutContext.Provider value={{setSelectedTabName, setSidebarOpen, mobile}}>
+                        <TabList />
+                    </LayoutContext.Provider>
                 </Box>
             </styles.Sidebar>
             

--- a/client/src/components/PageLayout.jsx
+++ b/client/src/components/PageLayout.jsx
@@ -53,18 +53,10 @@ export default function PageLayout() {
             </styles.Sidebar>
             
             <styles.ContentBox open={sidebarOpen} mobile={mobile}>
-                <styles.SidebarButton
-                    onClick={() => setSidebarOpen(!sidebarOpen)}
-                    disableTouchRipple
-                >
-                    ☰
-                </styles.SidebarButton>
                 <Box display='flex' flexDirection='column'>
-                    <Header title={selectedTabName}
-                            sidebarOpen={sidebarOpen}
-                            setSidebarOpen={setSidebarOpen}
-                            mobile={mobile}
-                    />
+                    <LayoutContext.Provider value={{selectedTabName, sidebarOpen, setSidebarOpen}}>
+                        <Header/>
+                    </LayoutContext.Provider>
                     <styles.PageContent mobile={mobile}>
                         <Outlet/>
                     </styles.PageContent>

--- a/client/src/components/PageLayout.jsx
+++ b/client/src/components/PageLayout.jsx
@@ -20,33 +20,35 @@ export default function PageLayout() {
     const [sidebarOpen, setSidebarOpen] = React.useState(!mobile);
     const [selectedTabName, setSelectedTabName] = useState('UMSATS');
 
+    const toggleSidebar = (newOpen) => () => {
+        setSidebarOpen(newOpen);
+    }
+
     return (
         <ThemeProvider theme={theme}>
         <CssBaseline />
-        <Box>
+        <Box display='inline'>
             <styles.Sidebar
                 open={sidebarOpen}
                 mobile={mobile}
-                variant='persistent'
+                variant={mobile ? 'temporary' : 'persistent'}
+                onClose={toggleSidebar(false)}
             >
                 <Box display='flex' flexDirection='column'>
                     <img src={bannerImage} alt='banner'
                          style={{margin: '12px', borderRadius: '8px'}}/>
-                    <TabList setSelectedTabName={setSelectedTabName}/>
+                    <TabList setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
                 </Box>
             </styles.Sidebar>
             
-            <styles.ContentBox open={sidebarOpen}>
+            <styles.ContentBox open={sidebarOpen} mobile={mobile}>
                 <styles.SidebarButton
                     onClick={() => setSidebarOpen(!sidebarOpen)}
-                    sx={{right: mobile && sidebarOpen ? '0' : ''}}
                     disableTouchRipple
                 >
                     ☰
                 </styles.SidebarButton>
-                <Box display='flex' flexDirection='column'
-                     sx={{display: mobile && sidebarOpen ? 'none' : 'flex'}} 
-                >
+                <Box display='flex' flexDirection='column'>
                     <Header title={selectedTabName}
                             sidebarOpen={sidebarOpen}
                             setSidebarOpen={setSidebarOpen}

--- a/client/src/components/TabList.jsx
+++ b/client/src/components/TabList.jsx
@@ -4,13 +4,13 @@ import TabListItem from './TabListItem.jsx';
 import { DashboardIcon, ExperimentIcon } from './TabListIcons.jsx';
 import './TabListIcons.css';
 
-export default function TabList({ setSelectedTabName, setSidebarOpen }) {
+export default function TabList() {
     return (
         <List disablePadding>
-          <TabListItem icon={<DashboardIcon />} name='Dashboard' href='/dashboard' setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
-          <TabListItem icon={<ExperimentIcon />} name='Experiment' href='/experiments' setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
-          <TabListItem name='Home Page' href='/' setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
-          <TabListItem name='Test Page' href='/test' setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
+          <TabListItem icon={<DashboardIcon />} name='Dashboard' href='/dashboard'/>
+          <TabListItem icon={<ExperimentIcon />} name='Experiment' href='/experiments'/>
+          <TabListItem name='Home Page' href='/'/>
+          <TabListItem name='Test Page' href='/test'/>
         </List>
     );
 }

--- a/client/src/components/TabList.jsx
+++ b/client/src/components/TabList.jsx
@@ -4,13 +4,13 @@ import TabListItem from './TabListItem.jsx';
 import { DashboardIcon, ExperimentIcon } from './TabListIcons.jsx';
 import './TabListIcons.css';
 
-export default function TabList({ setSelectedTabName }) {
+export default function TabList({ setSelectedTabName, setSidebarOpen }) {
     return (
         <List disablePadding>
-          <TabListItem icon={<DashboardIcon />} name='Dashboard' href='/dashboard' setSelectedTabName={setSelectedTabName}/>
-          <TabListItem icon={<ExperimentIcon />} name='Experiment' href='/experiments' setSelectedTabName={setSelectedTabName}/>
-          <TabListItem name='Home Page' href='/' setSelectedTabName={setSelectedTabName}/>
-          <TabListItem name='Test Page' href='/test' setSelectedTabName={setSelectedTabName}/>
+          <TabListItem icon={<DashboardIcon />} name='Dashboard' href='/dashboard' setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
+          <TabListItem icon={<ExperimentIcon />} name='Experiment' href='/experiments' setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
+          <TabListItem name='Home Page' href='/' setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
+          <TabListItem name='Test Page' href='/test' setSelectedTabName={setSelectedTabName} setSidebarOpen={setSidebarOpen}/>
         </List>
     );
 }

--- a/client/src/components/TabListItem.jsx
+++ b/client/src/components/TabListItem.jsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import Link from '@mui/material/Link';
 import * as styles from '../styled-components/TabListItemStyles.js';
+import { useLayoutContext } from './PageLayout.jsx';
 import { useNavigate } from 'react-router-dom';
 
-export default function TabListItem({ href, icon, name, setSelectedTabName, setSidebarOpen }) {
+export default function TabListItem({ href, icon, name }) {
     const selected = window.location.pathname === href;
     const navigate = useNavigate();
+    const Context = useLayoutContext();
 
     const handleClick = (event) => {
         event.preventDefault();
-        setSelectedTabName(name);
+        Context.setSelectedTabName(name);
         navigate(href);
-        setSidebarOpen(false);
+        if (Context.mobile) {Context.setSidebarOpen(false)};
     };
 
     return (

--- a/client/src/components/TabListItem.jsx
+++ b/client/src/components/TabListItem.jsx
@@ -3,7 +3,7 @@ import Link from '@mui/material/Link';
 import * as styles from '../styled-components/TabListItemStyles.js';
 import { useNavigate } from 'react-router-dom';
 
-export default function TabListItem({ href, icon, name, setSelectedTabName }) {
+export default function TabListItem({ href, icon, name, setSelectedTabName, setSidebarOpen }) {
     const selected = window.location.pathname === href;
     const navigate = useNavigate();
 
@@ -11,6 +11,7 @@ export default function TabListItem({ href, icon, name, setSelectedTabName }) {
         event.preventDefault();
         setSelectedTabName(name);
         navigate(href);
+        setSidebarOpen(false);
     };
 
     return (

--- a/client/src/components/theme.jsx
+++ b/client/src/components/theme.jsx
@@ -35,8 +35,8 @@ export const theme = createTheme({
     breakpoints: {
         values: {
             xs: 0,
-            mobile: 500,
             sm: 600,
+            mobile: 700,
             md: 900,
             lg: 1200,
             xl: 1536,

--- a/client/src/styled-components/HeaderStyles.js
+++ b/client/src/styled-components/HeaderStyles.js
@@ -1,8 +1,8 @@
 import {styled} from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 
 export const HeaderLeftBox = styled(Box)(() => ({
-    marginLeft: '2.5em',
     fontSize: '1.5em', 
     fontWeight: 'bold',
     textAlign: 'center', 
@@ -13,4 +13,13 @@ export const HeaderRightBox = styled(Box)(() => ({
     width: 'fit-content',
     right: '1em',
     position: 'absolute'
+}));
+
+export const SidebarButton = styled(Button)(() => ({
+    zIndex: '1200',
+    margin: '0 8px',
+    padding: '0',
+    fontSize: '25px',
+    fontWeight: '700',
+    color: '#888',
 }));

--- a/client/src/styled-components/HeaderStyles.js
+++ b/client/src/styled-components/HeaderStyles.js
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 
 export const HeaderLeftBox = styled(Box)(() => ({
+    display: 'flex',
     fontSize: '1.5em', 
     fontWeight: 'bold',
     textAlign: 'center', 
@@ -19,6 +20,9 @@ export const SidebarButton = styled(Button)(() => ({
     zIndex: '1200',
     margin: '0 8px',
     padding: '0',
+    '&.MuiButton-root': {
+        lineHeight: '0'
+    },
     fontSize: '25px',
     fontWeight: '700',
     color: '#888',

--- a/client/src/styled-components/PageLayoutStyles.js
+++ b/client/src/styled-components/PageLayoutStyles.js
@@ -12,7 +12,7 @@ export const Sidebar = styled(Drawer)((props) => ({
         width: props.mobile ? sidebarWidthMobile : sidebarWidth
     },
     '.MuiPaper-root': {
-        backgroundColor: theme.palette.background.sidebar,
+        backgroundColor: !props.mobile ? theme.palette.background.sidebar : '',
         borderRight: 0
     },
 }));

--- a/client/src/styled-components/PageLayoutStyles.js
+++ b/client/src/styled-components/PageLayoutStyles.js
@@ -2,7 +2,6 @@ import {styled} from '@mui/material/styles';
 import {theme} from '../components/theme.jsx';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
-import Button from '@mui/material/Button';
 
 const sidebarWidth = '400px';
 const sidebarWidthMobile = '75vw';
@@ -18,16 +17,6 @@ export const Sidebar = styled(Drawer)((props) => ({
     },
 }));
 
-export const SidebarButton = styled(Button)(() => ({
-    zIndex: '1200',
-    position: 'fixed',
-    fontSize: '25px',
-    fontWeight: '700',
-    color: '#888',
-    padding: '0',
-    height: '64px'
-}));
-
 export const ContentBox = styled(Box)((props) => ({
     transition: 'margin-left 225ms cubic-bezier(0, 0, 0.2, 1)',
     marginLeft: props.open && !props.mobile ? sidebarWidth : '0'
@@ -35,12 +24,4 @@ export const ContentBox = styled(Box)((props) => ({
 
 export const PageContent = styled(Box)((props) => ({
     margin: props.mobile ? '0 20px' : '0 60px'
-}));
-
-export const Header = styled(Box)(() => ({
-    height: '50px',
-    backgroundColor: theme.palette.background.page,
-    position: 'sticky',
-    top: '0',
-    width: '100%'
 }));

--- a/client/src/styled-components/PageLayoutStyles.js
+++ b/client/src/styled-components/PageLayoutStyles.js
@@ -5,11 +5,12 @@ import Drawer from '@mui/material/Drawer';
 import Button from '@mui/material/Button';
 
 const sidebarWidth = '400px';
+const sidebarWidthMobile = '75vw';
 
 export const Sidebar = styled(Drawer)((props) => ({
-    width: props.mobile ? '100%' : sidebarWidth,
+    width: props.mobile ? sidebarWidthMobile : sidebarWidth,
     '.MuiDrawer-paper': {
-        width: props.mobile ? '100%' : sidebarWidth
+        width: props.mobile ? sidebarWidthMobile : sidebarWidth
     },
     '.MuiPaper-root': {
         backgroundColor: theme.palette.background.sidebar,
@@ -29,7 +30,7 @@ export const SidebarButton = styled(Button)(() => ({
 
 export const ContentBox = styled(Box)((props) => ({
     transition: 'margin-left 225ms cubic-bezier(0, 0, 0.2, 1)',
-    marginLeft: props.open ? sidebarWidth : '0px'
+    marginLeft: props.open && !props.mobile ? sidebarWidth : '0'
 }));
 
 export const PageContent = styled(Box)((props) => ({


### PR DESCRIPTION
Features:
- The sidebar now uses the 'temporary' variant on mobile (similar to ChatGPT).
- Adds LayoutContext to PageLayout.jsx, allowing its children to access and change state without prop drilling.

Fixes:
- Choosing a tab on mobile now closes the sidebar.
- Choosing the already selected tab doesn't re-render the page.
- The sidebar button is now rendered in the header using context.