### PR TITLE
Feat: Greeting Dialog and Cookie

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "js-cookie": "^3.0.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.0",
@@ -12898,6 +12899,15 @@
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "js-cookie": "^3.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.0",

--- a/client/src/components/GreetingDialog.jsx
+++ b/client/src/components/GreetingDialog.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from 'react';
+import Cookies from 'js-cookie';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+
+// The cookie expires in 5 seconds - useful for testing, but should be
+// set to a longer period in the future.
+const COOKIE_EXPIRY = 5 / (60 * 60 * 24); // in days
+
+export default function GreetingDialog() {
+    const [open, setOpen] = React.useState(false);
+
+    const setShowGreetingDialog = (show) => {
+        if (Cookies.get('showGreetingDialog') !== 'false') {
+            Cookies.set('showGreetingDialog', show, { expires: COOKIE_EXPIRY });
+            setOpen(Cookies.get('showGreetingDialog') === 'true');
+        }
+    }
+
+    useEffect(() => {
+        setShowGreetingDialog('true')
+    }, [])
+
+    const handleClick = () => {
+        setShowGreetingDialog('false')
+    }
+    
+    return (
+        <Dialog open={open}>
+            <DialogTitle>
+                Welcome to JARVIS!
+            </DialogTitle>
+            <DialogActions>
+                <Button onClick={handleClick}>
+                    CLOSE
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}

--- a/client/src/components/GreetingDialog.jsx
+++ b/client/src/components/GreetingDialog.jsx
@@ -5,9 +5,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 
-// The cookie expires in 5 seconds - useful for testing, but should be
-// set to a longer period in the future.
-const COOKIE_EXPIRY = 5 / (60 * 60 * 24); // in days
+const COOKIE_EXPIRY = 7; // in days
 
 export default function GreetingDialog() {
     const [open, setOpen] = React.useState(false);

--- a/client/src/components/PageLayout.jsx
+++ b/client/src/components/PageLayout.jsx
@@ -14,6 +14,7 @@ import Box from '@mui/material/Box';
 import TabList from './TabList.jsx';
 import bannerImage from '../assets/banner.png';
 import Header from './Header.jsx';
+import GreetingDialog from './GreetingDialog.jsx';
 
 const LayoutContext = React.createContext(undefined);
 export function useLayoutContext() {
@@ -33,6 +34,8 @@ export default function PageLayout() {
         <ThemeProvider theme={theme}>
         <CssBaseline />
         <Box>
+            <GreetingDialog />
+
             <styles.Sidebar
                 open={sidebarOpen}
                 mobile={mobile}


### PR DESCRIPTION
Installs the `js-cookie` package for managing client-side sessions.

Creates a basic greeting popup using Material UI. By managing a cookie named `showGreetingDialog`, the popup is able to stay hidden after being closed even when refreshing the page (until the cookie expires). The expiry time is set to five seconds so that #41 is easy to test, but should obviously be increased later on.

The same structure can be used for managing other session variables in the future, but nothing is pertinent right now.

Note: [feat-sessionManagement](https://github.com/UMSATS/Jarvis/tree/feat-sessionManagement) is deprecated and will be deleted after merging this. The difference is that it implemented server-side session management, which is useful for things like authentication, but not needed (currently) for JARVIS.